### PR TITLE
Validate DATABASE_URL before creating pool

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6,9 +6,21 @@ declare global {
   var pgPool: Pool | undefined;
 }
 
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error('DATABASE_URL environment variable is required');
+}
+
 const pool = global.pgPool ?? new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
 });
+
+if (!global.pgPool) {
+  pool.on('error', (err) => {
+    console.error('Unexpected error on idle PostgreSQL client', err);
+  });
+}
 
 if (process.env.NODE_ENV !== 'production') {
   global.pgPool = pool;


### PR DESCRIPTION
## Summary
- Ensure `DATABASE_URL` exists before creating the PostgreSQL pool and throw an explicit error if missing
- Attach an `error` listener to log unexpected client issues

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and missing dependencies warnings)*
- `npm run typecheck` *(fails: TypeScript errors in equipment and warehouse modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d74a2d388331aa257ebabe9b08de