### PR TITLE
feat: add cache invalidation support

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,0 +1,18 @@
+# Cache Strategy
+
+This project uses a small in-memory cache for frequently queried data. Each
+`get*` function wraps its database call with a `cached` helper that stores the
+result by key. Mutating operations (`add*`, `update*`, `delete*`) call
+`invalidateCache` with the corresponding key to clear stale entries so that the
+next call refetches from the database.
+
+| Data set            | Cache key           | Mutations that invalidate |
+| ------------------- | ------------------- | ------------------------- |
+| Equipment           | `equipment`         | add/update/delete/log     |
+| Stores              | `stores`            | add/update/delete         |
+| Users               | `users`             | add/update                |
+| Warehouse components| `warehouse_components` | (read-only)           |
+| Warehouse insumos   | `warehouse_insumos` | (read-only)               |
+
+This manual invalidation strategy keeps API responses consistent after writes
+while avoiding unnecessary database queries.


### PR DESCRIPTION
## Summary
- replace React `cache` with manual in-memory cache helper
- clear cache entries after mutations so reads refetch updated data
- document cache invalidation strategy

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other warnings)*
- `npm run typecheck` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d74d4c348331b8964e0c655fd50d