### PR TITLE
Add SQL seed for default admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Copy `.env.example` to `.env.local` and update the values to match your setup:
 cp .env.example .env.local
 # edit .env.local to set DATABASE_URL
 ```
+
+## Database Seeding
+
+After setting `DATABASE_URL`, initialize the schema and insert the default admin user:
+
+```bash
+psql "$DATABASE_URL" -f db/schema.sql
+psql "$DATABASE_URL" -f db/init.sql
+```
+
+This seeds an `admin@paguemenos.com` account with the password `password` stored as a SHA-256 hash.

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,13 @@
+INSERT INTO users (id, data) VALUES (
+  'user-1',
+  jsonb_build_object(
+    'id', 'user-1',
+    'email', 'admin@paguemenos.com',
+    'password', '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    'name', 'Administrador do Sistema',
+    'cargo', 'Administrador de TI',
+    'role', 'Administrador',
+    'avatarUrl', ''
+  )
+)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- add `db/init.sql` to seed an admin user with a SHA-256 hashed password
- document database seeding steps in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*
- `npm run typecheck` *(fails: various TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d74e2c2c83318a9f625027536214