### PR TITLE
Handle SHA-256 seeded password gracefully

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -3,7 +3,7 @@ INSERT INTO users (id, data) VALUES (
   jsonb_build_object(
     'id', 'user-1',
     'email', 'admin@paguemenos.com',
-    'password', '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    'password', '$2b$10$WIPSINi022QSRHZzDiUzUu1wvc7mMivcWJcFytf1HMrlVvbg5ijuS',
     'name', 'Administrador do Sistema',
     'cargo', 'Administrador de TI',
     'role', 'Administrador',


### PR DESCRIPTION
## Summary
- handle bcrypt, SHA-256, and plain-text passwords to avoid 500 on login
- seed initial admin user with bcrypt hash

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and other warnings)*
- `npm run typecheck` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dab913788331a5c59e1ea1b0cec7