### PR TITLE
Handle SHA-256 seeded password gracefully

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -3,7 +3,7 @@ INSERT INTO users (id, data) VALUES (
   jsonb_build_object(
     'id', 'user-1',
     'email', 'admin@paguemenos.com',
-    'password', '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+    'password', '$2b$10$WIPSINi022QSRHZzDiUzUu1wvc7mMivcWJcFytf1HMrlVvbg5ijuS',
     'name', 'Administrador do Sistema',
     'cargo', 'Administrador de TI',
     'role', 'Administrador',

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -2,6 +2,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUsers } from "@/lib/api";
 import bcrypt from "bcrypt";
+import { createHash } from "crypto";
+
+function isConnRefused(err: unknown): boolean {
+  if (err && typeof err === "object") {
+    if ("code" in err && (err as any).code === "ECONNREFUSED") return true;
+    if ("errors" in err && Array.isArray((err as any).errors)) {
+      return (err as any).errors.some(e => isConnRefused(e));
+    }
+  }
+  return false;
+}
 
 export async function POST(req: NextRequest) {
   try {
@@ -9,19 +20,41 @@ export async function POST(req: NextRequest) {
     const users = await getUsers();
     const user = users.find(u => u.email === email);
 
-    if (user && user.password && (await bcrypt.compare(pass, user.password))) {
+    let passwordMatch = false;
+
+    if (user?.password) {
+      try {
+        if (user.password.startsWith("$2")) {
+          passwordMatch = await bcrypt.compare(pass, user.password);
+        } else if (/^[a-f0-9]{64}$/i.test(user.password)) {
+          const hashed = createHash("sha256").update(pass).digest("hex");
+          passwordMatch = hashed === user.password;
+        } else {
+          passwordMatch = pass === user.password;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    if (passwordMatch) {
       // In a real app, you'd create a session/JWT token here.
       // For this demo, we'll just confirm success.
       return NextResponse.json({ success: true });
-    } else {
-      return NextResponse.json({ success: false }, { status: 401 });
     }
+
+    return NextResponse.json({ success: false }, { status: 401 });
   } catch (error) {
     console.error(error);
+    const dbDown = isConnRefused(error);
+    const defaultMessage = dbDown ? "Database connection failed" : "Server error";
     const message =
       process.env.NODE_ENV === "development" && error instanceof Error
         ? error.message
-        : "Server error";
-    return NextResponse.json({ success: false, error: message }, { status: 500 });
+        : defaultMessage;
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: dbDown ? 503 : 500 }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- handle bcrypt, SHA-256, and plain-text passwords to avoid 500 on login
- seed initial admin user with bcrypt hash
- surface database connection failures with a clearer 503 response

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: multiple TS module resolution errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c0dab913788331a5c59e1ea1b0cec7